### PR TITLE
feat: add general reuse compliance lint

### DIFF
--- a/.github/workflows/reuse-lint-info.md
+++ b/.github/workflows/reuse-lint-info.md
@@ -1,0 +1,11 @@
+# REUSE Compliance check information
+
+This workflow checks if your project is REUSE compliant.
+Being REUSE compliant means that it follows a few basic rules regarding license information,
+which can be verified by running the REUSE Tool, and make sure it passes a "reuse lint" check.
+
+You can read more about REUSE [here](https://reuse.software/) our at our internal Open Source site. 
+Being REUSE compliant is one of the lint rules we have for releasing Open Source software at SVT.
+If it is not, you should fix it; it is quite easy - run 'reuse lint' on your project.
+
+See the official docs, or our internal help site [Open Source site](https://opensource.svt.se) for more guidance. If you need more information about this check then contact our internal #opensource or #ospo. 

--- a/.github/workflows/reuse-lint.yml
+++ b/.github/workflows/reuse-lint.yml
@@ -1,0 +1,33 @@
+name: REUSE compliance check
+
+on:
+  repository_dispatch:
+    types: [org-workflow-bot]  
+   
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: SvanBoxel/organization-workflow@main
+      with:
+        id: ${{ github.event.client_payload.id }}
+        callback_url: ${{ github.event.client_payload.callback_url }}
+        sha: ${{ github.event.client_payload.sha }}
+        run_id: ${{ github.run_id }}
+        name: ${{ github.workflow }}
+        enforce: false
+        enforce-admin: false
+        documentation: ".github/workflows/reuse-lint-info.md"
+
+  main:
+    needs: [register]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.client_payload.repository.full_name }}
+        ref: ${{ github.event.client_payload.sha }}
+        token: ${{ github.event.client_payload.token }}
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v1


### PR DESCRIPTION
Signed-off-by: Josef Andersson <josef.andersson@svt.se>

Adds a general reuse compliance lint check running under the general org workflow plugin for running on selected repos. Not enforced, 